### PR TITLE
Documentation generation can specify a target

### DIFF
--- a/cmake/run-cmake.sh
+++ b/cmake/run-cmake.sh
@@ -5,10 +5,10 @@ set -eu
 
 if [ "$(uname)" = "Darwin" ]; then
   if [ "$INPUT_CC" = "gcc" ]; then
-    INPUT_CC="gcc-10"
+    INPUT_CC="gcc-11"
   fi
   if [ "$INPUT_CXX" = "g++" ]; then
-    INPUT_CXX="g++-10"
+    INPUT_CXX="g++-11"
   fi
 fi
 

--- a/docs/action.yml
+++ b/docs/action.yml
@@ -1,6 +1,11 @@
 ---
 name: 'Generate Documentation'
 description: 'Generate Documentation'
+inputs:
+  docs-target:
+    description: The CMake target used to generate the docs
+    default: doc
+    required: false
 
 runs:
   using: 'composite'
@@ -8,3 +13,5 @@ runs:
     - id: documentation-coverage
       run: ${GITHUB_ACTION_PATH}/generate-docs.sh
       shell: bash
+      env:
+        TARGET: ${{ inputs.docs-target }}

--- a/docs/generate-docs.sh
+++ b/docs/generate-docs.sh
@@ -8,7 +8,7 @@ case $(uname) in
     mkdir build
     cd build
     cmake -DDOXYGEN_INPUT_FILTER=$GITHUB_ACTION_PATH/doxygen_spdx_filter.py -DDOXYGEN_GENERATE_XML=YES ..
-    cmake --build . --target doc
+    cmake --build . --target $TARGET
     ;;
 
   Darwin | Windows* | MINGW* | MSYS*)


### PR DESCRIPTION
The default `docs` target can be overridden using an input.