### PR TITLE
Parameterized initialization

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-name: ci
+name: build-test
 
 on:
   push:
@@ -34,6 +34,8 @@ jobs:
         run-test: true
     - name: Generate Documentation
       uses: ./docs
+      with:
+        docs-target: doc-for-test
     - name: Documentation Coverage
       uses: ./docs-coverage
       with:

--- a/.github/workflows/optional-init.yml
+++ b/.github/workflows/optional-init.yml
@@ -17,7 +17,6 @@ jobs:
       uses: ./init
       with:
         with-mpi: no
-        with-llvm: no
         with-doxygen: no
     - name: Verify initialization
       run: |

--- a/.github/workflows/optional-init.yml
+++ b/.github/workflows/optional-init.yml
@@ -1,0 +1,33 @@
+name: optional-init
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: REUSE check
+      uses: ./reuse-check
+    - name: Initialize Environment
+      uses: ./init
+      with:
+        with-mpi: no
+        with-llvm: no
+        with-doxygen: no
+    - name: Verify initialization
+      run: |
+        exists()
+        {
+          command -v "$1" >/dev/null 2>&1
+        }
+        if exists mpicc; then
+          exit 1
+        fi
+        if exists doxygen; then
+          exit 1
+        fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,4 +16,4 @@ add_test(test_program test_program)
 add_test(test_program_cpp test_program_cpp)
 
 find_package(Doxygen)
-doxygen_add_docs(doc ".")
+doxygen_add_docs(doc-for-test ".")

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ build_and_test:
       - name: Checkpout repository
         uses: actions/checkout@v3
       - name: Initialize Environment
-        uses: ROOT-Sim/ci-actions/init@v1.2
+        uses: ROOT-Sim/ci-actions/init@v1.3
       - name: Build & Test
-        uses: ROOT-Sim/ci-actions/cmake@v1.2
+        uses: ROOT-Sim/ci-actions/cmake@v1.3
         with:
           build-dir: ${{ runner.workspace }}/build
           cc: ${{ matrix.compiler }}
@@ -52,12 +52,22 @@ build_and_test:
           run-test: true
 ```
 
-In order to generate the documentation of the project, the following step can be included, which requires that a target
-named `doc` is present in `CMakeLists.txt` to generate the Doxygen documentation:
+In order to generate the documentation of the project, the following step can be included to generate the Doxygen
+documentation:
 
 ```yaml
     - name: Generate Documentation
-      uses: ROOT-Sim/ci-actions/docs@v1.2
+      uses: ROOT-Sim/ci-actions/docs@v1.3
+```
+
+Note that in the above case, it is automatically triggering the build of a `doc` target from `CMakeLists.txt`.
+If the target to generate Doxygen documentation is different, it can be specified with the `docs-target` parameter:
+
+```yaml
+    - name: Generate Documentation
+      uses: ROOT-Sim/ci-actions/docs@v1.3
+      with:
+        docs-target: build-documentation
 ```
 
 If you want to perform a documentation coverage, the following step can be included. It *must* come after the `docs`
@@ -65,7 +75,7 @@ action. If running in a pull request, it will comment the pull request with info
 
 ```yaml
     - name: Documentation Coverage
-      uses: ROOT-Sim/ci-actions/docs-coverage@v1.2
+      uses: ROOT-Sim/ci-actions/docs-coverage@v1.3
       with:
         accept-threshold: "60.0"
         build-path: build/docs
@@ -94,7 +104,7 @@ If you want to perform a REUSE check (which fails the CI if the check does not p
 
 ```yaml
     - name: REUSE check
-      uses: ROOT-Sim/ci-actions/reuse-check@v1.2
+      uses: ROOT-Sim/ci-actions/reuse-check@v1.3
 ```
 
 Another available action allows to deploy the documentation into a GitHub Pages website in the current repository.
@@ -102,7 +112,7 @@ This action can be used as such:
 
 ```yaml
     - name: Website Deployment
-      uses: ROOT-Sim/ci-actions/website-deploy@v1.2
+      uses: ROOT-Sim/ci-actions/website-deploy@v1.3
 ```
 
 The documentation will be deployed in the `/docs/[branchname]/` path, where `[branchname]` is either `master` or 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ build_and_test:
       - name: Checkpout repository
         uses: actions/checkout@v3
       - name: Initialize Environment
-        uses: ROOT-Sim/ci-actions/init@v1.3
+        uses: ROOT-Sim/ci-actions/init@v1.4
       - name: Build & Test
-        uses: ROOT-Sim/ci-actions/cmake@v1.3
+        uses: ROOT-Sim/ci-actions/cmake@v1.4
         with:
           build-dir: ${{ runner.workspace }}/build
           cc: ${{ matrix.compiler }}
@@ -52,12 +52,26 @@ build_and_test:
           run-test: true
 ```
 
+Note that the `init` action, by default, installs all the dependencies that are used by the ROOT-Sim
+core project, both for building and for documentation purposes. Among them, there are the MPI library
+and Doxygen. These dependencies take time to be configured, especially on Windows and Linux. If some
+project does not need them, they can be phased out from the initialization. This can be done as
+follows:
+
+```yaml
+    - name: Initialize Environment
+      uses: ROOT-Sim/ci-actions/init@v1.4
+      with:
+        with-mpi: no
+        with-doxygen: no
+```
+
 In order to generate the documentation of the project, the following step can be included to generate the Doxygen
 documentation:
 
 ```yaml
     - name: Generate Documentation
-      uses: ROOT-Sim/ci-actions/docs@v1.3
+      uses: ROOT-Sim/ci-actions/docs@v1.4
 ```
 
 Note that in the above case, it is automatically triggering the build of a `doc` target from `CMakeLists.txt`.
@@ -65,9 +79,9 @@ If the target to generate Doxygen documentation is different, it can be specifie
 
 ```yaml
     - name: Generate Documentation
-      uses: ROOT-Sim/ci-actions/docs@v1.3
+      uses: ROOT-Sim/ci-actions/docs@v1.4
       with:
-        docs-target: build-documentation
+        docs-target: generate-documentation
 ```
 
 If you want to perform a documentation coverage, the following step can be included. It *must* come after the `docs`
@@ -75,7 +89,7 @@ action. If running in a pull request, it will comment the pull request with info
 
 ```yaml
     - name: Documentation Coverage
-      uses: ROOT-Sim/ci-actions/docs-coverage@v1.3
+      uses: ROOT-Sim/ci-actions/docs-coverage@v1.4
       with:
         accept-threshold: "60.0"
         build-path: build/docs
@@ -104,7 +118,7 @@ If you want to perform a REUSE check (which fails the CI if the check does not p
 
 ```yaml
     - name: REUSE check
-      uses: ROOT-Sim/ci-actions/reuse-check@v1.3
+      uses: ROOT-Sim/ci-actions/reuse-check@v1.4
 ```
 
 Another available action allows to deploy the documentation into a GitHub Pages website in the current repository.
@@ -112,7 +126,7 @@ This action can be used as such:
 
 ```yaml
     - name: Website Deployment
-      uses: ROOT-Sim/ci-actions/website-deploy@v1.3
+      uses: ROOT-Sim/ci-actions/website-deploy@v1.4
 ```
 
 The documentation will be deployed in the `/docs/[branchname]/` path, where `[branchname]` is either `master` or 

--- a/init/action.yml
+++ b/init/action.yml
@@ -1,6 +1,15 @@
 ---
 name: 'Initialize Environment'
 description: 'Install packages required by ROOT-Sim development.'
+inputs:
+  with-mpi:
+    description: Specify whether to provide MPI in the environment
+    default: yes
+    required: false
+  with-doxygen:
+    description: Specify whether to configure Doxygen in the environment
+    default: yes
+    required: false
 
 runs:
   using: 'composite'
@@ -8,9 +17,13 @@ runs:
     - id: setup-mpi
       run: ${GITHUB_ACTION_PATH}/setup-mpi.sh
       shell: bash
+      env:
+        WITHMPI: ${{ inputs.with-mpi }}
     - id: setup-llvm
       run: ${GITHUB_ACTION_PATH}/setup-llvm.sh
       shell: bash
     - id: setup-doxygen
       run: ${GITHUB_ACTION_PATH}/setup-doxygen.sh
       shell: bash
+      env:
+        WITHDOXYGEN: ${{ inputs.with-doxygen }}

--- a/init/setup-doxygen.sh
+++ b/init/setup-doxygen.sh
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 set -eu
 
+if test "x$WITHDOXYGEN" = 'xno'; then
+  exit 0
+fi
+
 case $(uname) in
   Linux)
    sudo apt-get update

--- a/init/setup-mpi.sh
+++ b/init/setup-mpi.sh
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 set -eu
 
+if test "x$WITHMPI" = 'xno'; then
+  exit 0
+fi
+
 case $(uname) in
   Linux)
    sudo apt install -y -q openmpi-bin libopenmpi-dev


### PR DESCRIPTION
When initializing the build environment, we can disable the configuration of:
- MPI
- Doxygen

The reason is that the various projects all rely on CMake and LLVM, but not all subprojects make use of MPI and Doxygen.
Since configuring all this stuff takes time (especially on Windows and Mac), we can disable unneeded stuff to make tests run faster.